### PR TITLE
Update Rust CI for multi-OS builds and release automation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,22 +1,69 @@
-name: Rust
+name: Rust CI and Release
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
+    tags:
+      - "v*"
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
+  build-and-test:
+    if: startsWith(github.ref, 'refs/tags/') == false
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build (release)
+        run: cargo build --release --verbose
+      - name: Run tests
+        run: cargo test --verbose
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build release
+        run: cargo build --release --verbose
+      - name: Package (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
+          bin_name="dummy-rs"
+          mkdir -p dist
+          cp "target/release/${bin_name}" "dist/"
+          tar -czf "dist/${bin_name}-${{ runner.os }}.tar.gz" -C dist "${bin_name}"
+          rm "dist/${bin_name}"
+        shell: bash
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $bin = "dummy-rs.exe"
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Copy-Item "target\release\$bin" dist\
+          Compress-Archive -Path "dist\$bin" -DestinationPath "dist\dummy-rs-Windows.zip" -Force
+          Remove-Item "dist\$bin"
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.tar.gz
+            dist/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
```
### Summary

This pull request updates the Rust CI pipeline to:
- Support builds on multiple operating systems.
- Add a release workflow for improved automation.
- Enable tag-triggered releases for simplified version deployments.


```